### PR TITLE
feat: Renovate trusted-publisher allowlist with Tier 1 + Tier 2 rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     {
       "description": "Tier 1: Automerge own and official GitHub Actions (all update types)",
       "matchManagers": ["github-actions"],
-      "matchPackagePrefixes": ["actions/", "jacobpevans/"],
+      "matchPackagePrefixes": ["actions/", "JacobPEvans/"],
       "automerge": true,
       "automergeType": "squash"
     },


### PR DESCRIPTION
Updates Renovate configuration to use explicit allowlist instead of minimal config:recommended.

**Tier 1 (all update types):** actions/, jacobpevans/
**Tier 2 (minor/patch only):** aquasecurity/, googleapis/, terraform-linters/

Enables auto-merge for known, trusted publishers.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `renovate.json` to use a tiered allowlist for automerging updates from trusted publishers.
> 
>   - **Behavior**:
>     - Updates `renovate.json` to use explicit allowlist instead of `config:recommended`.
>     - Adds Tier 1 rules for automerging all update types from `actions/` and `jacobpevans/`.
>     - Adds Tier 2 rules for automerging minor/patch updates from `aquasecurity/`, `googleapis/`, and `terraform-linters/`.
>     - Enables automerge with squash for pre-commit minor/patch updates.
>   - **Misc**:
>     - Enables auto-merge for trusted publishers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Ftf-splunk-aws&utm_source=github&utm_medium=referral)<sup> for 3bf0ebb7bc130cf83cb98ddc0ec969c80d103b3e. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->