### PR TITLE
feat(renovate): extend shared preset, remove duplicated rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "matchPackagePrefixes": ["terraform-linters/"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
-      "automergeType": "squash"
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Extends `local>JacobPEvans/.github:renovate-presets` to inherit org-wide auto-merge rules
- Removes local packageRules now covered by shared preset (actions/, googleapis/, pre-commit, aquasecurity/)
- Retains tflint-ruleset minor/patch automerge rule (repo-specific)

## Why

Centralizes Renovate auto-merge configuration in the `.github` repo preset, eliminating duplication.

## Test plan

- [ ] Merge `.github` PR #69 first (preset must be on main before Renovate runs)
- [ ] Verify next Renovate PR gets auto-merge enabled at creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extends `renovate.json` with shared preset for auto-merge rules, removing redundant local rules except for `tflint-ruleset`.
> 
>   - **Configuration**:
>     - Extends `renovate.json` with `local>JacobPEvans/.github:renovate-presets` for org-wide auto-merge rules.
>     - Removes local `packageRules` for `actions/`, `googleapis/`, `pre-commit`, `aquasecurity/` now covered by shared preset.
>     - Retains `tflint-ruleset` minor/patch automerge rule in `renovate.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Ftf-splunk-aws&utm_source=github&utm_medium=referral)<sup> for 0dbc670efc70df589856fd66e5e6f3b1bdd6aa2f. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->