### PR TITLE
🤖 Fix #42: enable auto-lifecycle in dev terragrunt config

### DIFF
--- a/terragrunt/dev/terragrunt.hcl
+++ b/terragrunt/dev/terragrunt.hcl
@@ -41,6 +41,9 @@ inputs = {
   web_allowed_cidrs = local.allowed_cidrs
   hec_allowed_cidrs = local.allowed_cidrs
 
+  # Auto-lifecycle: start Splunk every 4h for 60min (~$9/mo vs ~$18/mo always-on)
+  enable_auto_lifecycle = true
+
   # Splunk admin password: uses Doppler SPLUNK_PASSWORD if set, otherwise auto-generates
   splunk_admin_password = local.splunk_password != "" ? local.splunk_password : null
 }


### PR DESCRIPTION
Closes #42

## Problem

`terragrunt/dev/terragrunt.hcl` was not updated after PR #41 merged the `enable_auto_lifecycle` feature. The new variable defaults to `false`, so the auto-lifecycle cost-saving feature (start Splunk every 4h for 60min, ~$9/mo vs ~$18/mo) is silently disabled in the dev environment.

## Approach

Add `enable_auto_lifecycle = true` to the `inputs` block in `terragrunt/dev/terragrunt.hcl`. The `auto_shutdown_minutes` (60) and `lifecycle_interval_hours` (4) defaults already match the documented target configuration.

## Files changed

- `terragrunt/dev/terragrunt.hcl` — add `enable_auto_lifecycle = true` to inputs block

## CI status

passed — Lint Markdown ✅

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
