### PR TITLE
chore: remove SmartStore S3 backend from Splunk module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,8 @@ DATA FLOW
   On-Prem Splunk -> HEC (port 8088) -> AWS Splunk Receiver (private subnet via NAT)
   Cloud Sources  -> HEC (port 8088) -> AWS Splunk Receiver
 
-SmartStore (S3 remote index storage)
-  Splunk warm/cold index buckets -> S3 bucket (see Terraform outputs)
-  Data persists in S3 even when instance is stopped — searchable on-demand via start
+LONG-TERM ARCHIVE
+  Cribl writes directly to S3 outside this module — Splunk indexes stay local on EBS.
 
 NETWORK
   VPC: 10.0.0.0/16
@@ -41,12 +40,10 @@ NETWORK
 | NAT (t4g.nano) | ~$2.52/mo | ~$2.52/mo |
 | Splunk (t4g.small) | ~$12.18/mo | ~$3.05/mo (25% utilization) |
 | EBS (70GB gp3) | ~$2.97/mo | ~$2.97/mo |
-| S3 SmartStore | ~$0.50/mo | ~$0.50/mo |
-| **Total** | **~$18.17/mo** | **~$9/mo** |
+| **Total** | **~$17.67/mo** | **~$8.54/mo** |
 
-SmartStore is live: warm/cold index buckets tier to S3-IA (30d) then Glacier (90d).
 Auto-lifecycle (`enable_auto_lifecycle = true`) starts Splunk every 4 hours for 60 minutes via EventBridge Scheduler.
-Data persists in S3 even when instance is stopped — searchable on-demand via start.
+Index data lives on the EBS data volume; long-term archive is handled by Cribl writing directly to S3 outside this module.
 
 ## Technology Stack
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![License](https://img.shields.io/github/license/JacobPEvans/tf-splunk-aws)](LICENSE)
 
 Cost-optimized Splunk infrastructure on AWS using OpenTofu and Terragrunt.
-**~$9–$18.17/month** (SmartStore + optional auto-lifecycle).
+**~$8.54–$17.67/month** (optional auto-lifecycle). Long-term archive is handled
+by Cribl writing directly to S3 outside this module.
 
 ## What & Why
 
@@ -13,7 +14,7 @@ Cost-optimized Splunk infrastructure on AWS using OpenTofu and Terragrunt.
 
 ## Quick Facts
 
-- **Cost**: ~$18.17/month always-on; ~$9/month with `enable_auto_lifecycle = true`
+- **Cost**: ~$17.67/month always-on; ~$8.54/month with `enable_auto_lifecycle = true`
 - **Architecture**: 4 modules (network, security, compute, splunk)
 - **Deployment**: Terragrunt-managed with remote state
 - **Security**: Encrypted storage, IAM least privilege, VPC isolation
@@ -25,11 +26,10 @@ Cost-optimized Splunk infrastructure on AWS using OpenTofu and Terragrunt.
 | NAT Instance (t4g.nano) | $2.52 | $2.52 |
 | Splunk Instance (t4g.small) | $12.18 | ~$3.05 (25% utilization) |
 | EBS Storage (70GB GP3) | $2.97 | $2.97 |
-| S3 SmartStore | ~$0.50 | ~$0.50 |
-| **Total** | **~$18.17** | **~$9** |
+| **Total** | **~$17.67** | **~$8.54** |
 
-SmartStore persists all index data to S3 (warm/cold → S3-IA at 30d → Glacier at 90d).
-Data remains searchable on-demand even when the instance is stopped.
+Index data lives on the local EBS volume. Cribl handles long-term archive to S3
+out-of-band, so this module no longer manages a SmartStore bucket.
 Auto-lifecycle (`enable_auto_lifecycle = true`) starts Splunk every 4 hours for 60 minutes.
 
 ## Quick Start

--- a/docs/instance-management.md
+++ b/docs/instance-management.md
@@ -8,8 +8,7 @@ without destroying any infrastructure or data.
 | Resource | Persists? | Notes |
 | ---------- | --------- | ----- |
 | EBS root volume | Yes | OS, Splunk install, config |
-| EBS data volume | Yes | Splunk index data (hot/warm) |
-| S3 SmartStore | Yes | Cold/frozen index data |
+| EBS data volume | Yes | Splunk index data (hot/warm/cold) |
 | SSM parameters | Yes | Admin password |
 | Security groups | Yes | Firewall rules |
 | IAM role | Yes | Instance permissions |
@@ -17,7 +16,8 @@ without destroying any infrastructure or data.
 | **Public IP** | **No** | New IP assigned on each start |
 | Instance ID | Yes | Does not change |
 
-> EBS data + S3 SmartStore = full index history survives any stop/start cycle.
+> EBS data volume holds the full Splunk index history across any stop/start cycle.
+> Long-term archive lives in a separate Cribl-managed S3 bucket outside this module.
 
 ---
 
@@ -30,8 +30,7 @@ without destroying any infrastructure or data.
 | NAT t4g.nano (us-east-2) | ~$2.52 |
 | Splunk t3a.small (us-east-2) | ~$12.18 |
 | EBS 70 GB gp3 | ~$2.97 |
-| S3 SmartStore | ~$0.50 |
-| **Total** | **~$18.17** |
+| **Total** | **~$17.67** |
 
 ### Paused (instances stopped, data retained)
 
@@ -40,8 +39,7 @@ without destroying any infrastructure or data.
 | NAT t4g.nano — stopped | $0.00 |
 | Splunk t3a.small — stopped | $0.00 |
 | EBS 70 GB gp3 (still billed) | ~$2.97 |
-| S3 SmartStore | ~$0.50 |
-| **Total** | **~$3.47** |
+| **Total** | **~$2.97** |
 
 ### With Auto-Lifecycle (EventBridge scheduled)
 
@@ -51,8 +49,8 @@ Default config: start every 4 hours, run 60 minutes = ~25% utilization.
 | ---------- | ------- |
 | Splunk t3a.small × 25% | ~$3.05 |
 | NAT t4g.nano (must stay on for egress routing) | ~$2.52 |
-| EBS + S3 | ~$3.47 |
-| **Total** | **~$9.04** |
+| EBS | ~$2.97 |
+| **Total** | **~$8.54** |
 
 ---
 
@@ -95,7 +93,7 @@ aws-vault exec tf-splunk-aws -- aws ec2 wait instance-stopped \
   --region us-east-2
 ```
 
-Both instances are now stopped. EBS and S3 continue to bill; compute does not.
+Both instances are now stopped. EBS continues to bill; compute does not.
 
 ---
 
@@ -154,7 +152,7 @@ does not create plan drift. A `terragrunt plan` after pause will show no changes
 
 Allow ~2–3 minutes after `instance-running` before Splunk Web is reachable.
 On resume, Splunk starts via the boot-start service; first-boot provisioning
-(package install, SSM password retrieval, SmartStore config) does not repeat.
+(package install, SSM password retrieval) does not repeat.
 
 ### Data ingestion during pause
 
@@ -169,8 +167,8 @@ If you want automated cost control without manual steps, set
 EventBridge Scheduler to start Splunk on a configurable interval
 (`lifecycle_interval_hours`, default 4) and shut it down automatically after
 `auto_shutdown_minutes` (default 60). The NAT instance must remain running to
-provide egress routing for the Splunk instance (private-subnet traffic to S3,
-SSM, and other AWS endpoints routes through NAT).
+provide egress routing for the Splunk instance (private-subnet traffic to SSM
+and other AWS endpoints routes through NAT).
 
 ### Elastic IP (EIP)
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -46,7 +46,6 @@ Splunk infrastructure:
 - Encrypted EBS volumes for data storage
 - CloudWatch integration for logging
 - User data scripts for Splunk setup
-- SmartStore S3 backend: warm/cold index buckets persist to S3 (data survives instance termination)
 - Auto-lifecycle management: Automated start/stop cycle via EventBridge Scheduler and instance user data
 
 ## Key Features
@@ -55,8 +54,7 @@ Splunk infrastructure:
 - CloudWatch integration for monitoring
 - Automated user data scripts
 - Proper security group configuration
-- SmartStore S3 backend: index data persists to S3 and is searchable on-demand
-- Auto-lifecycle management: ~$9/mo with `enable_auto_lifecycle = true` vs ~$18.17/mo always-on
+- Auto-lifecycle management: ~$8.54/mo with `enable_auto_lifecycle = true` vs ~$17.67/mo always-on
 
 ## 💰 Cost Efficiency
 

--- a/modules/main.tf
+++ b/modules/main.tf
@@ -49,9 +49,6 @@ provider "criblio" {
   cloud_domain    = var.cribl_cloud_domain
 }
 
-# AWS account identity - used for unique S3 bucket naming
-data "aws_caller_identity" "current" {}
-
 # Auto-generated credentials for ephemeral dev/DR environments
 # All secrets are generated per-build and destroyed with the environment
 resource "random_password" "splunk_admin" {
@@ -137,69 +134,6 @@ data "aws_ami" "windows_2022" {
   }
 }
 
-# SmartStore S3 Bucket - remote storage for Splunk warm/cold index buckets
-# Created at root level to break circular dependency: security needs ARN for IAM, splunk needs name for config
-resource "aws_s3_bucket" "smartstore" {
-  bucket = "${var.environment}-splunk-smartstore-${data.aws_caller_identity.current.account_id}"
-
-  tags = {
-    Environment = var.environment
-    Project     = "splunk-aws"
-    ManagedBy   = "terraform"
-    Name        = "${var.environment}-splunk-smartstore"
-  }
-}
-
-resource "aws_s3_bucket_versioning" "smartstore" {
-  bucket = aws_s3_bucket.smartstore.id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "smartstore" {
-  bucket = aws_s3_bucket.smartstore.id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
-    }
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "smartstore" {
-  bucket = aws_s3_bucket.smartstore.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-resource "aws_s3_bucket_lifecycle_configuration" "smartstore" {
-  bucket = aws_s3_bucket.smartstore.id
-
-  rule {
-    id     = "smartstore-tiering"
-    status = "Enabled"
-
-    transition {
-      days          = 30
-      storage_class = "STANDARD_IA"
-    }
-
-    transition {
-      days          = 90
-      storage_class = "GLACIER_IR"
-    }
-
-    noncurrent_version_expiration {
-      noncurrent_days = 90
-    }
-  }
-}
-
 # Network Module
 module "network" {
   source = "./network"
@@ -224,7 +158,6 @@ module "security" {
   hec_allowed_cidrs        = var.hec_allowed_cidrs
   web_allowed_cidrs        = var.web_allowed_cidrs
   allow_all_ips            = var.allow_all_ips
-  smartstore_bucket_arn    = aws_s3_bucket.smartstore.arn
   enable_cribl             = var.enable_cribl
   management_allowed_cidrs = var.management_allowed_cidrs
   cribl_allowed_cidrs      = var.cribl_allowed_cidrs
@@ -262,7 +195,6 @@ module "splunk" {
   ami_id                       = data.aws_ami.amazon_linux_x86.id
   splunk_version               = var.splunk_version
   splunk_build                 = var.splunk_build
-  smartstore_bucket_name       = aws_s3_bucket.smartstore.bucket
   enable_auto_lifecycle        = var.enable_auto_lifecycle
   auto_shutdown_minutes        = var.auto_shutdown_minutes
   lifecycle_interval_hours     = var.lifecycle_interval_hours

--- a/modules/outputs.tf
+++ b/modules/outputs.tf
@@ -122,13 +122,13 @@ output "estimated_cost" {
   description = "Estimated daily and monthly cost in USD (always-on vs auto-lifecycle)"
   value = var.enable_cribl ? {
     daily = {
-      always_on      = "$2.55/day"
-      auto_lifecycle = "$2.25/day"
+      always_on      = "$2.57/day"
+      auto_lifecycle = "$2.26/day"
       breakdown      = "NAT: $0.08, Splunk: $0.41 (always-on) / $0.10 (lifecycle), Stream: $0.46, Edge/Win: $1.41, EBS: $0.21"
     }
     monthly = {
       always_on      = "$77/mo"
-      auto_lifecycle = "$67/mo"
+      auto_lifecycle = "$68/mo"
       breakdown      = "NAT: $2.52, Splunk: $12.18 (always-on) / $3.05 (lifecycle), Stream: $13.74, Edge/Win: $42.34, EBS: $6.17"
     }
     } : {

--- a/modules/outputs.tf
+++ b/modules/outputs.tf
@@ -117,36 +117,30 @@ output "cribl_security_group_id" {
   value       = module.security.cribl_security_group_id
 }
 
-# SmartStore S3 Bucket
-output "smartstore_bucket_name" {
-  description = "Name of the S3 bucket used for Splunk SmartStore remote storage"
-  value       = aws_s3_bucket.smartstore.bucket
-}
-
 # Cost Estimation
 output "estimated_cost" {
   description = "Estimated daily and monthly cost in USD (always-on vs auto-lifecycle)"
   value = var.enable_cribl ? {
     daily = {
-      always_on      = "$2.57/day"
-      auto_lifecycle = "$2.27/day"
-      breakdown      = "NAT: $0.08, Splunk: $0.41 (always-on) / $0.10 (lifecycle), Stream: $0.46, Edge/Win: $1.41, EBS: $0.21, S3: ~$0.02"
+      always_on      = "$2.55/day"
+      auto_lifecycle = "$2.25/day"
+      breakdown      = "NAT: $0.08, Splunk: $0.41 (always-on) / $0.10 (lifecycle), Stream: $0.46, Edge/Win: $1.41, EBS: $0.21"
     }
     monthly = {
       always_on      = "$77/mo"
-      auto_lifecycle = "$68/mo"
-      breakdown      = "NAT: $2.52, Splunk: $12.18 (always-on) / $3.05 (lifecycle), Stream: $13.74, Edge/Win: $42.34, EBS: $6.17, S3: ~$0.50"
+      auto_lifecycle = "$67/mo"
+      breakdown      = "NAT: $2.52, Splunk: $12.18 (always-on) / $3.05 (lifecycle), Stream: $13.74, Edge/Win: $42.34, EBS: $6.17"
     }
     } : {
     daily = {
-      always_on      = "$0.61/day"
-      auto_lifecycle = "$0.30/day"
-      breakdown      = "NAT: $0.08, Splunk: $0.41 (always-on) / $0.10 (lifecycle), EBS: $0.10, S3: ~$0.02"
+      always_on      = "$0.59/day"
+      auto_lifecycle = "$0.28/day"
+      breakdown      = "NAT: $0.08, Splunk: $0.41 (always-on) / $0.10 (lifecycle), EBS: $0.10"
     }
     monthly = {
-      always_on      = "$18.17/mo"
-      auto_lifecycle = "$9/mo"
-      breakdown      = "NAT: $2.52, Splunk: $12.18 (always-on) / $3.05 (lifecycle), EBS: $2.97, S3: ~$0.50"
+      always_on      = "$17.67/mo"
+      auto_lifecycle = "$8.54/mo"
+      breakdown      = "NAT: $2.52, Splunk: $12.18 (always-on) / $3.05 (lifecycle), EBS: $2.97"
     }
   }
 }

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -241,20 +241,6 @@ resource "aws_iam_role_policy" "splunk_instance" {
           "ec2:DescribeTags"
         ]
         Resource = "*"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:GetBucketLocation",
-          "s3:ListBucket"
-        ]
-        Resource = [
-          var.smartstore_bucket_arn,
-          "${var.smartstore_bucket_arn}/*"
-        ]
       }
     ]
   })
@@ -380,7 +366,7 @@ resource "aws_iam_role" "cribl_instance" {
   })
 }
 
-# IAM Policy for Cribl Instances (SSM management only — no S3 SmartStore access)
+# IAM Policy for Cribl Instances (SSM management only — no module-managed S3 access)
 resource "aws_iam_role_policy" "cribl_instance" {
   count = var.enable_cribl ? 1 : 0
 

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -52,11 +52,6 @@ variable "allow_all_ips" {
   default     = false
 }
 
-variable "smartstore_bucket_arn" {
-  description = "ARN of the S3 bucket used for Splunk SmartStore remote storage"
-  type        = string
-}
-
 variable "enable_cribl" {
   description = "Enable Cribl Stream and Edge resources (security groups, IAM)"
   type        = bool

--- a/modules/splunk/main.tf
+++ b/modules/splunk/main.tf
@@ -56,6 +56,31 @@ locals {
     # Install CloudWatch agent
     yum install -y amazon-cloudwatch-agent
 
+    # Mount the dedicated EBS data volume at /opt/splunk before installing Splunk.
+    # The instance attaches a gp3 volume at /dev/sdf (variable: splunk_data_volume_size).
+    # Without mounting, Splunk writes indexes to the small root volume and the data
+    # volume sits unused.
+    DATA_DEV=""
+    for candidate in /dev/nvme1n1 /dev/xvdf /dev/sdf; do
+      if [ -b "$candidate" ]; then
+        DATA_DEV="$candidate"
+        break
+      fi
+    done
+    if [ -z "$DATA_DEV" ]; then
+      echo "ERROR: Splunk data volume not found at /dev/nvme1n1, /dev/xvdf, or /dev/sdf." >&2
+      exit 1
+    fi
+    if ! blkid "$DATA_DEV" >/dev/null 2>&1; then
+      mkfs.xfs -f "$DATA_DEV"
+    fi
+    mkdir -p /opt/splunk
+    DATA_UUID=$(blkid -s UUID -o value "$DATA_DEV")
+    if ! grep -q "$DATA_UUID" /etc/fstab; then
+      echo "UUID=$DATA_UUID /opt/splunk xfs defaults,noatime 0 2" >> /etc/fstab
+    fi
+    mount /opt/splunk
+
     # Create splunk user
     useradd -r -m -s /bin/bash splunk
 

--- a/modules/splunk/main.tf
+++ b/modules/splunk/main.tf
@@ -68,29 +68,6 @@ locals {
     tar -xzf "$${SPLUNK_PKG}"
     chown -R splunk:splunk /opt/splunk
 
-    # Configure SmartStore (S3 remote storage for warm/cold buckets)
-    # Must run before first Splunk start so indexes are created with SmartStore enabled
-    mkdir -p /opt/splunk/etc/system/local
-
-    cat > /opt/splunk/etc/system/local/indexes.conf << 'INDEXES'
-[volume:s3_store]
-storageType = remote
-path = s3://${var.smartstore_bucket_name}/smartstore
-
-[default]
-remotePath = volume:s3_store/$_index_name
-repFactor = 0
-maxDataSize = auto
-INDEXES
-
-    cat > /opt/splunk/etc/system/local/server.conf << 'SERVER'
-[cachemanager]
-max_cache_size = 5120
-eviction_policy = lru
-SERVER
-
-    chown -R splunk:splunk /opt/splunk/etc/system/local
-
     # Retrieve Splunk admin password from SSM Parameter Store (never stored in user_data)
     SPLUNK_PASSWORD=$(aws ssm get-parameter \
       --name "${var.splunk_password_ssm_name}" \

--- a/modules/splunk/variables.tf
+++ b/modules/splunk/variables.tf
@@ -82,11 +82,6 @@ variable "splunk_build" {
   }
 }
 
-variable "smartstore_bucket_name" {
-  description = "Name of the S3 bucket used for Splunk SmartStore remote storage"
-  type        = string
-}
-
 variable "enable_auto_lifecycle" {
   description = "Enable automatic start/stop lifecycle for Splunk instance"
   type        = bool

--- a/modules/tests/outputs.tftest.hcl
+++ b/modules/tests/outputs.tftest.hcl
@@ -220,18 +220,6 @@ run "nat_instance_outputs_are_present" {
   }
 }
 
-# --- SmartStore S3 bucket name is exposed ---
-# The smartstore_bucket_name output must be present for Ansible/ops to configure S3 access.
-
-run "smartstore_bucket_name_is_non_null" {
-  command = plan
-
-  assert {
-    condition     = output.smartstore_bucket_name != null
-    error_message = "smartstore_bucket_name output must be non-null"
-  }
-}
-
 # --- Cribl outputs are present when enabled (default) ---
 
 run "cribl_outputs_are_present" {


### PR DESCRIPTION
## Summary

- Strategic shift: Cribl now handles long-term archive directly to S3 outside this module, so Splunk's SmartStore S3 backend is no longer needed.
- Removes the S3 bucket and its lifecycle/encryption/versioning/public-access-block resources, plus the IAM S3 policy and the SmartStore user-data config block.
- Updates cost tables (~$17.67 always-on / ~$8.54 auto-lifecycle, monthly) and prunes SmartStore from the architecture narratives.

## Why

- Splunk index data is small enough to live on the EBS data volume; the SmartStore bucket was costing ~$0.50/mo and complexity for no benefit once Cribl handles archive externally.
- Closes #46 (SmartStore S3 security tests) and supersedes #172 — those tests harden code being removed.

## Test plan

- [x] `cd modules && tofu init -backend=false && tofu validate` passes
- [x] `tofu test -no-color` — 67/67 pass
- [ ] After merge: `cd terragrunt/dev && terragrunt plan` shows exactly 5 S3 resources to destroy
- [ ] After merge: `terragrunt apply` destroys the bucket; Splunk Web and Cribl Stream Web both come back up within 5 min

Refs #46 #172