### PR TITLE
fix(splunk): drop redundant set web-port/restart that broke pipefail

### DIFF
--- a/modules/splunk/main.tf
+++ b/modules/splunk/main.tf
@@ -113,12 +113,10 @@ locals {
     # Enable Splunk to start at boot
     /opt/splunk/bin/splunk enable boot-start -user splunk
 
-    # Splunk Web defaults to port 8000; no `set web-port` needed.
-    # No restart needed either — `splunk start` above already brought the daemon up
-    # with the seeded admin password. The previous user_data ran `splunk set web-port`
-    # followed by `splunk restart` here, which both require an authenticated CLI
-    # session that the seed-passwd flow doesn't establish. Under `set -eo pipefail`
-    # those non-zero exits killed the rest of the user_data script.
+    # Splunk Web defaults to port 8000 and the daemon is already running from the
+    # `splunk start --seed-passwd` call above. `set web-port` and `restart` are
+    # avoided here because they require an authenticated CLI session, which the
+    # seed-passwd flow does not establish.
     %{if var.enable_auto_lifecycle}
 
     # Auto-lifecycle: schedule shutdown ${var.auto_shutdown_minutes} minutes after every boot.

--- a/modules/splunk/main.tf
+++ b/modules/splunk/main.tf
@@ -113,9 +113,12 @@ locals {
     # Enable Splunk to start at boot
     /opt/splunk/bin/splunk enable boot-start -user splunk
 
-    # Configure basic settings
-    sudo -u splunk /opt/splunk/bin/splunk set web-port 8000
-    sudo -u splunk /opt/splunk/bin/splunk restart
+    # Splunk Web defaults to port 8000; no `set web-port` needed.
+    # No restart needed either — `splunk start` above already brought the daemon up
+    # with the seeded admin password. The previous user_data ran `splunk set web-port`
+    # followed by `splunk restart` here, which both require an authenticated CLI
+    # session that the seed-passwd flow doesn't establish. Under `set -eo pipefail`
+    # those non-zero exits killed the rest of the user_data script.
     %{if var.enable_auto_lifecycle}
 
     # Auto-lifecycle: schedule shutdown ${var.auto_shutdown_minutes} minutes after every boot.


### PR DESCRIPTION
## Summary

- Removes two user_data commands (\`splunk set web-port 8000\` + \`splunk restart\`) that always exit non-zero in the seed-passwd boot flow.
- Combined with \`set -eo pipefail\`, those non-zero exits killed the rest of user_data and made cloud-init log \`Failed running /var/lib/cloud/instance/scripts/part-001 [1]\` on every Splunk boot.
- Both commands are redundant: 8000 is Splunk Web's default port, and the daemon is already running from the preceding \`splunk start --seed-passwd\` call.

## Why

Discovered during post-apply validation of #184. Splunk Web came up regardless because \`start\` succeeded earlier in the script, but the script then exited 1 — meaning any future post-start steps would silently never run. Brittle.

## Test plan

- [x] \`tofu validate\` passes
- [x] \`tofu test -no-color\` — 70/70 pass
- [ ] After apply: cloud-init finishes without the \`Failed running ... part-001\` warning
- [ ] After apply: Splunk Web on the instance returns 303 on \`localhost:8000\`