### PR TITLE
🤖 Fix #183: mock_provider SG ID collision in isolation run

### DIFF
--- a/modules/tests/security.tftest.hcl
+++ b/modules/tests/security.tftest.hcl
@@ -172,6 +172,16 @@ run "nat_and_splunk_security_groups_are_separate" {
   }
 
   assert {
+    condition     = output.nat_security_group_id == "sg-00000000000000001"
+    error_message = "nat_security_group_id output must surface the NAT SG, not the Splunk SG (catches swapped wiring)"
+  }
+
+  assert {
+    condition     = output.splunk_security_group_id == "sg-00000000000000002"
+    error_message = "splunk_security_group_id output must surface the Splunk SG, not the NAT SG (catches swapped wiring)"
+  }
+
+  assert {
     condition     = output.nat_security_group_id != output.splunk_security_group_id
     error_message = "NAT and Splunk must have separate security groups for least-privilege access control"
   }

--- a/modules/tests/security.tftest.hcl
+++ b/modules/tests/security.tftest.hcl
@@ -157,6 +157,20 @@ run "security_group_outputs_are_non_null" {
 run "nat_and_splunk_security_groups_are_separate" {
   command = plan
 
+  override_resource {
+    target = module.security.aws_security_group.nat_instance
+    values = {
+      id = "sg-00000000000000001"
+    }
+  }
+
+  override_resource {
+    target = module.security.aws_security_group.splunk
+    values = {
+      id = "sg-00000000000000002"
+    }
+  }
+
   assert {
     condition     = output.nat_security_group_id != output.splunk_security_group_id
     error_message = "NAT and Splunk must have separate security groups for least-privilege access control"

--- a/scripts/tofu-test-isolation-check.sh
+++ b/scripts/tofu-test-isolation-check.sh
@@ -38,12 +38,7 @@ echo ">>> Check 2: per-file isolation"
 # Pre-existing isolation failures are tracked as repo issues and excluded here
 # rather than via bypassing the check. Add new entries only with a linked issue
 # in the comment.
-exclude_files=(
-  # tests/security.tftest.hcl: nat/splunk SG output equality assertion collides
-  # under mock_provider random ID generation.
-  # Tracked: https://github.com/JacobPEvans/tf-splunk-aws/issues/183
-  "tests/security.tftest.hcl"
-)
+exclude_files=()
 isolation_failures=()
 for f in "${test_files[@]}"; do
   rel="${f#${repo_root}/modules/}"


### PR DESCRIPTION
Closes #183

## Problem

`tests/security.tftest.hcl` run `nat_and_splunk_security_groups_are_separate` asserts `output.nat_security_group_id != output.splunk_security_group_id`. When the file runs in isolation (`tofu test -filter=tests/security.tftest.hcl`), `mock_provider "aws"` returns the **same** random ID for both `aws_security_group.nat_instance` and `aws_security_group.splunk`, causing the assertion to fail.

In the full suite this passes because another test file's `override_module` leaks distinct mocked SG IDs — exactly the cross-file leakage `docs/terraform-testing-standards.md §5` warns against.

## Approach

Add `override_resource` blocks inside the `nat_and_splunk_security_groups_are_separate` run to pin distinct, deterministic IDs (`sg-00000000000000001` / `sg-00000000000000002`) for the two security groups. This makes the assertion pass in strict isolation without any cross-file leakage.

After fixing the test, remove the `tests/security.tftest.hcl` exclusion entry from `scripts/tofu-test-isolation-check.sh`.

## Files changed

- `modules/tests/security.tftest.hcl` — add `override_resource` blocks with distinct IDs in `nat_and_splunk_security_groups_are_separate` run
- `scripts/tofu-test-isolation-check.sh` — remove `security.tftest.hcl` from Check 2 exclusion list

## CI status

pending — https://github.com/JacobPEvans/tf-splunk-aws/commits/fix/issue-183-mock-sg-id-collision

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
