### PR TITLE
fix(ci): retarget reusable-workflow uses: refs to current org homes

### DIFF
--- a/.github/workflows/ai-merge-gate.yml
+++ b/.github/workflows/ai-merge-gate.yml
@@ -3,5 +3,5 @@ on: pull_request
 permissions: read-all
 jobs:
   gate:
-    uses: JacobPEvans/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
     secrets: inherit

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@v0.16
     secrets: inherit

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.16
     with:
       workflow_name: "Terraform CI"
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/ci-fix.yml@v0.16
     with:
       repo_context: "Terraform/OpenTofu managing AWS Splunk DR infrastructure"
       ci_structure: "terraform.yml (tofu fmt/init/validate/test), markdown-lint.yml (markdownlint)"

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/code-simplifier.yml@v0.16
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/final-pr-review.yml@v0.16
     secrets: inherit

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
     with:
       operation: ${{ inputs.operation || 'compile' }}
     secrets:

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -65,7 +65,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@v0.16
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -76,7 +76,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/issue-resolver.yml@v0.16
     secrets: inherit
     with:
       repo_context: "Terraform/OpenTofu managing AWS Splunk DR infrastructure"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@v0.16
     secrets: inherit

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@v0.16
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/next-steps.yml@v0.16
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.16
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-tests.yml@v0.16
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Root cause

GitHub Actions `uses:` does not follow repository transfer/rename redirects and does not support variables. All `uses: JacobPEvans/…` references in this repo pointed at the old owner and fail at workflow parse time.

## Changes

| Old | New |
|-----|-----|
| `uses: JacobPEvans/ai-workflows/…` | `uses: dryvist/ai-workflows/…` |
| `uses: JacobPEvans/.github/…` | `uses: JacobPEvans-personal/.github/…` |

14 files changed, 15 `uses:` lines corrected. `.lock.yml` files skipped (5 present, none contained `JacobPEvans/` refs).

Part of an org-wide sweep of repos affected by the JacobPEvans → dryvist org migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)