### PR TITLE
chore: adopt dryvist org-default gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,78 @@ tmp/
 
 # ai-workflows runtime checkout (checked out by CI into .ai-workflows/ at runtime)
 .ai-workflows/
+
+# ---------------------------------------------------------------------
+# dryvist org-default: secrets, credentials & AI-assistant local state
+# Source of truth: dryvist/.github -> configs/gitignore (PR #43).
+# Carve-outs intentionally absent (committed by convention): .envrc,
+# *.sops.*, .terraform.lock.hcl
+# ---------------------------------------------------------------------
+
+# Environment files (committed examples kept via negation)
+.env.local
+.env.*.local
+!.env.*.example
+
+# Private keys & certificates
+*.ppk
+id_rsa
+id_rsa*
+id_ed25519
+id_ed25519*
+
+# SOPS / age private keys (*.sops.* ciphertext stays committed)
+*.age
+keys.txt
+
+# Ansible Vault
+*.vault
+vault.yml
+vault.yaml
+.vault_pass
+.vault_password
+.vault-pass*
+.vault-password*
+
+# Generic secret material
+secrets.yml
+secrets.yaml
+*.secrets.yml
+*.secrets.yaml
+secrets.dec.yaml
+secrets.plain.yaml
+*credentials*
+SECRETS_SETUP.md
+
+# Cloud provider credentials
+.azure/
+gcloud-credentials.json
+kubeconfig
+*.kubeconfig
+
+# Doppler secrets fallback cache (encrypted snapshot of the WHOLE config) + setup
+doppler.json
+.doppler/
+
+# Terraform / OpenTofu state & tfvars are secret-bearing
+**/.terraform/*
+*.tfstate.backup
+*.tfplan
+!*.tfvars.example
+
+# AI assistant machine-local state (committed .claude/settings.json, rules, CLAUDE.md stay)
+.claude/settings.local.json
+.claude/.credentials.json
+.claude/projects/
+.claude/shell-snapshots/
+.claude/statsig/
+.claude/todos/
+.claude/local/
+.claude/worktrees/
+.claude-wt/
+CLAUDE.local.md
+.CLAUDE.local.md
+GEMINI.local.md
+AGENTS.local.md
+.aider*
+.specstory/


### PR DESCRIPTION
## Summary

Standardizes `.gitignore` coverage as part of an org-wide hygiene initiative.
Ensures common credential, secret-material, infrastructure-state, and tool-local
artifact paths are ignored consistently across dryvist repos, so files that
shouldn't be in version control aren't tracked by accident.

Adopts the relevant subset of the org-default baseline (`dryvist/.github` →
`configs/gitignore`). Append-only and de-duplicated — no existing entries are
modified or removed. Verified that no currently-tracked file becomes ignored.

Intentional carve-outs preserved (committed by convention): `.envrc`,
`*.sops.*`, and `.terraform.lock.hcl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
