### PR TITLE
docs(readme): make standalone — drop cross-repo narrative, link the hub

### DIFF
--- a/.readme-validator.yaml
+++ b/.readme-validator.yaml
@@ -1,5 +1,6 @@
 required_sections:
-  - Quick Start
+  - Installation
+  - Usage
 optional_sections:
   - What & Why
   - Cost Breakdown

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 [![License](https://img.shields.io/github/license/JacobPEvans/tf-splunk-aws)](LICENSE)
 
 Cost-optimized Splunk infrastructure on AWS using OpenTofu and Terragrunt.
-**~$8.54–$17.67/month** (optional auto-lifecycle). Long-term archive is handled
-by Cribl writing directly to S3 outside this module.
+**~$8.54–$17.67/month** (optional auto-lifecycle). This module provisions a
+Splunk-ready AWS footprint — network, security, compute, and a running Splunk
+instance — that a downstream configurator can take over for index and data setup.
 
 ## What & Why
 
@@ -28,11 +29,30 @@ by Cribl writing directly to S3 outside this module.
 | EBS Storage (70GB GP3) | $2.97 | $2.97 |
 | **Total** | **~$17.67** | **~$8.54** |
 
-Index data lives on the local EBS volume. Cribl handles long-term archive to S3
-out-of-band, so this module no longer manages a SmartStore bucket.
-Auto-lifecycle (`enable_auto_lifecycle = true`) starts Splunk every 4 hours for 60 minutes.
+Index data lives on the local EBS volume. This module deliberately stops at the
+storage boundary: long-term archive to S3 is left to an out-of-band pipeline and
+is not managed here. Auto-lifecycle (`enable_auto_lifecycle = true`) starts
+Splunk every 4 hours for 60 minutes.
 
-## Quick Start
+## Installation
+
+This repo pins its toolchain (`tofu`, `terragrunt`, and friends) in a
+[Nix dev shell][nix-develop], wired up through the committed `.envrc`. Activate it
+once per worktree — `direnv` reads `.envrc` and loads the shell automatically:
+
+```bash
+direnv allow
+```
+
+AWS credentials must be available in the environment (the remote state backend
+and provider both authenticate against AWS).
+
+[nix-develop]: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-develop.html
+
+## Usage
+
+Each environment lives under `terragrunt/` (`dev`, `stg`, `prod`). Plan and apply
+from the target environment directory:
 
 ```bash
 cd terragrunt/dev
@@ -47,3 +67,7 @@ terragrunt apply   # Deploy infrastructure
 | **[Project Scope](.copilot/PROJECT.md)** | Business context, constraints | 2 min |
 | **[Architecture](.copilot/ARCHITECTURE.md)** | Technical decisions, current state | 5 min |
 | **[Implementation](modules/README.md)** | Module details, developer guide | 10 min |
+
+---
+
+> Part of a [larger ecosystem of ~40 repos](https://docs.jacobpevans.com) — see how it all fits together.


### PR DESCRIPTION
## Summary

Apply the README standard to `tf-splunk-aws`: the README now describes **only this repo**, with cross-repo context deferred to the docs hub.

- **Reframed the storage boundary as a contract.** Replaced the external-tool archive narrative ("Cribl handles long-term archive to S3 out-of-band") with a boundary statement: this module provisions a Splunk-ready AWS footprint and stops at the local EBS volume; long-term S3 archive is left to an out-of-band downstream pipeline — no sibling/tool named.
- **`## Quick Start` → `## Installation`** (Nix dev shell + `direnv allow`), plus a new **`## Usage`** section for the `terragrunt plan`/`apply` flow across the `dev`/`stg`/`prod` environments.
- **Added the shared ecosystem-hub footer** linking to docs.jacobpevans.com.
- **Aligned `.readme-validator.yaml`** `required_sections` to `Installation` and `Usage` to match the new headings (check kept, not disabled).

Self-referential CI/License badges (this repo's own) are retained — they are standard README content, not cross-repo references.

## Linear

JAC-141

## Test plan

- `python3 validate-readme.py README.md` → exit 0 (required sections present, config aligned)
- `markdownlint-cli2 README.md` (repo `.markdownlint.yml`, via Nix devShell) → 0 errors
- `grep -niE 'ansible-splunk|terraform-proxmox|nix-|tofu-|cc-edge|cribl'` → no sibling-repo names; remaining `nix-develop` is a markdown link label to the official nixos.org docs
- Only `github.com` reference is this repo's own CI badge