### PR TITLE
docs: genericize Doppler secret source references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,8 +176,8 @@ tofu test -no-color
 
 | Variable | Source | Purpose |
 | -------- | ------ | ------- |
-| `SPLUNK_PASSWORD` | `iac-conf-mgmt/prd` | Splunk admin password (>= 8 chars) |
-| `NETWORK_PUBLIC_IP_ADDRESS` | `iac-conf-mgmt/prd` | Home IP for web/HEC CIDR allowlists |
+| `SPLUNK_PASSWORD` | Doppler | Splunk admin password (>= 8 chars) |
+| `NETWORK_PUBLIC_IP_ADDRESS` | Doppler | Home IP for web/HEC CIDR allowlists |
 
 ## Module Structure
 

--- a/terragrunt/dev/terragrunt.hcl
+++ b/terragrunt/dev/terragrunt.hcl
@@ -36,7 +36,7 @@ inputs = {
   management_allowed_cidrs = local.allowed_cidrs
   cribl_allowed_cidrs      = local.allowed_cidrs
 
-  # CIDRs from Doppler NETWORK_PUBLIC_IP_ADDRESS (iac-conf-mgmt/prd)
+  # CIDRs from Doppler NETWORK_PUBLIC_IP_ADDRESS
   # Never commit real IPs — empty default disables external access if env var unset
   web_allowed_cidrs = local.allowed_cidrs
   hec_allowed_cidrs = local.allowed_cidrs


### PR DESCRIPTION
## Summary

Genericizes how this public repo documents its Doppler-sourced secrets so the docs no longer name internal vault structure.

- `AGENTS.md` — the "Source" column for `SPLUNK_PASSWORD` and `NETWORK_PUBLIC_IP_ADDRESS` now reads `Doppler` instead of a specific project/config path.
- `terragrunt/dev/terragrunt.hcl` — dropped the trailing parenthetical from the `NETWORK_PUBLIC_IP_ADDRESS` comment (comment-only; not functional config).

Env-var and secret **key** names are unchanged. No functional/config changes — docs + one comment only.

## Verification

`grep -rn "iac-conf-mgmt\|GH_ACTION_DOPPLER_IAC_CONF_MGMT"` returns no matches on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019whZYTbrt4DnoyXVE5gCF9