### PR TITLE
fix: point callers at renamed cc- reusable workflows

### DIFF
--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: dryvist/ai-workflows/.github/workflows/ci-fix.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/cc-ci-fix.yml@v0.16
     with:
       repo_context: "Terraform/OpenTofu managing AWS Splunk DR infrastructure"
       ci_structure: "terraform.yml (tofu fmt/init/validate/test), markdown-lint.yml (markdownlint)"

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: dryvist/ai-workflows/.github/workflows/code-simplifier.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/cc-code-simplifier.yml@v0.16
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -76,7 +76,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: dryvist/ai-workflows/.github/workflows/issue-resolver.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/cc-issue-resolver.yml@v0.16
     secrets: inherit
     with:
       repo_context: "Terraform/OpenTofu managing AWS Splunk DR infrastructure"

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: dryvist/ai-workflows/.github/workflows/next-steps.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/cc-next-steps.yml@v0.16
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: dryvist/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/cc-post-merge-docs-review.yml@v0.16
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: dryvist/ai-workflows/.github/workflows/post-merge-tests.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/cc-post-merge-tests.yml@v0.16
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
## Problem
Callers referenced `dryvist/ai-workflows/.github/workflows/<name>.yml@main` for
reusables that were renamed with a `cc-` prefix. The old names no longer exist,
so those runs failed at **startup** (0 jobs, "workflow file issue").

## Fix
Repoint the stale `uses:` refs to the current `cc-`-prefixed names
(cc-ci-fix / cc-code-simplifier / cc-issue-resolver / cc-next-steps /
cc-post-merge-docs-review / cc-post-merge-tests). Reusables that were never
renamed (issue-triage, best-practices, ci-fail-issue, issue-hygiene,
issue-sweeper) are left untouched. Pure reference rename, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)