### PR TITLE
feat: credential-less summon via GitHub Actions OIDC

### DIFF
--- a/.github/workflows/summon.yml
+++ b/.github/workflows/summon.yml
@@ -1,0 +1,104 @@
+# Summon — start or stop the environment from the Actions tab (or the Slack
+# GitHub app) with zero AWS credentials. Authenticates via GitHub OIDC to the
+# role created by modules/summon (enable_github_summon = true).
+#
+# Required repository Actions variables (from `tofu output` after apply):
+#   SUMMON_ROLE_ARN  — module output summon_role_arn
+# Optional repository Actions variables:
+#   AWS_REGION   (default us-east-2)
+#   PROJECT_TAG  (default splunk-aws)
+#
+# The scheduled stop (modules/lifecycle) stops the stack on its schedule
+# regardless of how it was started.
+
+name: Summon environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Start or stop the environment
+        type: choice
+        required: true
+        default: start
+        options:
+          - start
+          - stop
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: summon
+  cancel-in-progress: false
+
+jobs:
+  summon:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-2' }}
+      PROJECT_TAG: ${{ vars.PROJECT_TAG || 'splunk-aws' }}
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ vars.SUMMON_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Start environment
+        if: inputs.action == 'start'
+        run: |
+          set -euo pipefail
+
+          # NAT first: private-subnet instances need their egress path up
+          # before they boot and reach for packages/AWS APIs.
+          nat_ids=$(aws ec2 describe-instances \
+            --filters "Name=tag:Project,Values=${PROJECT_TAG}" "Name=tag:Role,Values=nat" "Name=instance-state-name,Values=stopped" \
+            --query 'Reservations[].Instances[].InstanceId' --output text)
+          if [ -n "$nat_ids" ]; then
+            aws ec2 start-instances --instance-ids $nat_ids
+            aws ec2 wait instance-running --instance-ids $nat_ids
+          fi
+
+          other_ids=$(aws ec2 describe-instances \
+            --filters "Name=tag:Project,Values=${PROJECT_TAG}" "Name=instance-state-name,Values=stopped" \
+            --query 'Reservations[].Instances[?!(Tags[?Key==`Role` && Value==`nat`])][].InstanceId' --output text)
+          if [ -n "$other_ids" ]; then
+            aws ec2 start-instances --instance-ids $other_ids
+            aws ec2 wait instance-running --instance-ids $other_ids
+          fi
+
+          if [ -z "$nat_ids" ] && [ -z "$other_ids" ]; then
+            echo "No stopped Project=${PROJECT_TAG} instances found." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Stop environment
+        if: inputs.action == 'stop'
+        run: |
+          set -euo pipefail
+          ids=$(aws ec2 describe-instances \
+            --filters "Name=tag:Project,Values=${PROJECT_TAG}" "Name=instance-state-name,Values=running" \
+            --query 'Reservations[].Instances[].InstanceId' --output text)
+          if [ -n "$ids" ]; then
+            aws ec2 stop-instances --instance-ids $ids
+            echo "Stopping: $ids" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No running Project=${PROJECT_TAG} instances found." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Report instance status
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo ""
+            echo "## Environment status (${{ inputs.action }})"
+            echo ""
+            echo "| Instance | State | Public IP | Private IP |"
+            echo "| --- | --- | --- | --- |"
+            aws ec2 describe-instances \
+              --filters "Name=tag:Project,Values=${PROJECT_TAG}" \
+              --query 'Reservations[].Instances[].[Tags[?Key==`Name`]|[0].Value, State.Name, PublicIpAddress, PrivateIpAddress]' \
+              --output text | awk '{printf "| %s | %s | %s | %s |\n", $1, $2, $3, $4}'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,261 +1,121 @@
 # tf-splunk-aws
 
-AWS Splunk DR/backup infrastructure managed with Terraform and Terragrunt.
+AWS Splunk/Cribl data-ingest infrastructure managed with OpenTofu (no
+Terraform, no Terragrunt).
 
 ## Purpose
 
-This repo provisions a cost-optimized AWS environment for backup/DR of a local home-lab Splunk instance. Key constraints:
+This repo provisions a cost-optimized AWS environment for on-demand Splunk
+and/or Cribl workloads. Key constraints:
 
-- Data flows **INTO** AWS only (never out - egress costs)
-- Only a minimal data receiver needs 24/7 uptime
-- Search capability is on-demand (start/stop as needed)
+- Data flows **INTO** AWS only (never out — egress costs)
+- Nothing needs 24/7 uptime; the environment is summoned on demand and a
+  scheduled stop turns it off again (default nightly, caps runtime under 24h)
 - Cost sensitivity is paramount
+- Splunk and Cribl are independently optional (`enable_splunk`,
+  `enable_cribl`)
 
 ## Architecture
 
 ```text
-MODULES
-  network  -> VPC, subnets, route tables (us-east-2)
-  security -> Security groups, IAM role/profile
-  compute  -> NAT instance (t4g.nano, public subnet)
-  splunk   -> Splunk Enterprise (t4g.small, private subnet)
-
-DATA FLOW
-  On-Prem Splunk -> HEC (port 8088) -> AWS Splunk Receiver (private subnet via NAT)
-  Cloud Sources  -> HEC (port 8088) -> AWS Splunk Receiver
-
-LONG-TERM ARCHIVE
-  Cribl writes directly to S3 outside this module — Splunk indexes stay local on EBS.
+ROOT MODULE (repo root)
+  modules/network    -> VPC, subnets, route tables
+  modules/security   -> Security groups, IAM roles/profiles, SSM password
+  modules/compute    -> NAT instance (t4g.nano, public subnet)
+  modules/splunk     -> Splunk Enterprise (t3a.small x86, optional)
+  modules/cribl      -> Cribl Stream (Linux) + Cribl Edge (Windows) (optional)
+  modules/cribl-config -> Declarative Cribl objects (criblio provider, optional)
+  modules/lifecycle  -> Scheduled stop of Project-tagged instances via the
+                        AWS-StopEC2Instance runbook (EventBridge Scheduler)
+  modules/summon     -> GitHub Actions OIDC role for credential-less
+                        start/stop
 
 NETWORK
   VPC: 10.0.0.0/16
-  Public:  10.0.1.0/24, 10.0.2.0/24 (NAT instance lives here)
-  Private: 10.0.10.0/24, 10.0.20.0/24 (Splunk lives here)
+  Public:  10.0.1.0/24, 10.0.2.0/24 (NAT lives here)
+  Private: 10.0.10.0/24, 10.0.20.0/24 (workloads by default)
 ```
 
-## Cost
+## Technology stack
 
-| Resource | Running | Stopped (by guardrail) |
-| -------- | ------- | ---------------------- |
-| NAT (t4g.nano) | ~$2.52/mo | $0 |
-| Splunk (t3a.small) | ~$12.18/mo | $0 |
-| EBS (70GB gp3) | ~$2.97/mo | ~$2.97/mo |
-| **Total** | **~$17.67/mo** | **~$2.97/mo** |
-
-The `enable_auto_stop` guardrail runs the AWS-owned `AWS-StopEC2Instance` runbook on a
-schedule (nightly by default) via EventBridge Scheduler, stopping every
-`Project=splunk-aws` instance — no Lambda, tag-driven. Index data lives on the EBS data
-volume; long-term archive is handled by Cribl writing directly to S3 outside this module.
-
-## Technology Stack
-
-- **Terraform/OpenTofu** >= 1.0
-- **AWS Provider** ~> 6.0
-- **Terragrunt** for environment management
-- **SSM Parameter Store** for secrets (Splunk admin password stored as SecureString)
-
-## Dev Shell Activation
-
-This repo uses the shared [nix-devenv terraform shell](https://github.com/JacobPEvans/nix-devenv/tree/main/shells/terraform)
-via direnv for reproducible tooling:
-
-```bash
-# Automatic (recommended): direnv activates on cd
-cd ~/git/tf-splunk-aws/main/
-direnv allow    # one-time per worktree
-
-# Manual:
-nix develop "github:JacobPEvans/nix-devenv?dir=shells/terraform"
-```
-
-## Claude Code with AWS Credentials
-
-Claude Code cannot access the macOS keychain for `aws-vault` prompts. To run
-Terragrunt operations (init, plan, apply, destroy) from Claude, **start the
-session with credentials already injected**:
-
-```bash
-# Launch Claude Code with AWS credentials pre-loaded
-aws-vault exec tf-splunk-aws -- doppler run -- claude
-
-# All Bash tool calls inside the session inherit AWS_* and Doppler env vars.
-# No aws-vault or doppler wrapper needed on individual commands:
-#   terragrunt init
-#   terragrunt plan
-#   terragrunt apply
-#   terragrunt destroy -auto-approve
-```
-
-STS credentials last ~1 hour. If they expire mid-session, exit and re-launch.
-
-### Post-Apply: Always Show Cost and Credentials
-
-After **every** `terragrunt apply` (or any change to this module), always run and
-display these outputs to the user:
-
-```bash
-cd terragrunt/dev/
-terragrunt output -json estimated_cost | jq .
-terragrunt output -json access_credentials | jq .
-```
-
-Then **verify all service URLs are live** before reporting success:
-
-```bash
-# Check Splunk Web (expect HTTP 303 redirect to login)
-curl -sf -o /dev/null -w '%{http_code}' http://<splunk_ip>:8000 || echo "SPLUNK DOWN"
-
-# Check Cribl Stream Web UI (expect HTTP 200 or 302)
-curl -sf -o /dev/null -w '%{http_code}' http://<cribl_stream_ip>:4200 || echo "CRIBL STREAM DOWN"
-```
-
-Services may take 2-5 minutes to boot after apply. Retry up to 3 times with 30-second
-intervals before reporting a service as down. Report results alongside the cost/credentials output.
-
-Offline operations (validate, test) never need credentials — run them directly:
-
-```bash
-cd modules/
-tofu init -backend=false
-tofu validate
-tofu test -no-color
-```
+- **OpenTofu** >= 1.10 (`tofu` CLI only — never generate `terraform` or
+  `terragrunt` commands)
+- **AWS provider** ~> 6.0
+- **S3 remote state** with native lockfile locking (no DynamoDB)
+- **SSM Parameter Store** for instance secrets
 
 ## Commands
 
-### Prerequisites
-
-- `aws-vault` for AWS credential management
-- `doppler` for environment variable injection (if using Doppler secrets)
-
-### Remote State Bootstrap (first-time / new AWS account)
-
-The S3 bucket and DynamoDB table for Terragrunt remote state must exist before running
-`terragrunt init`. They are created manually once per account:
+Offline validation and tests need no credentials:
 
 ```bash
-# Create S3 bucket (deterministic name — no random suffix)
-aws-vault exec tf-splunk-aws -- aws s3api create-bucket \
-  --bucket tf-splunk-aws-state-useast2-$(aws-vault exec tf-splunk-aws -- aws sts get-caller-identity --query Account --output text) \
-  --region us-east-2 \
-  --create-bucket-configuration LocationConstraint=us-east-2
-
-# Enable versioning and encryption
-aws-vault exec tf-splunk-aws -- aws s3api put-bucket-versioning \
-  --bucket tf-splunk-aws-state-useast2-<ACCOUNT_ID> \
-  --versioning-configuration Status=Enabled
-
-aws-vault exec tf-splunk-aws -- aws s3api put-bucket-encryption \
-  --bucket tf-splunk-aws-state-useast2-<ACCOUNT_ID> \
-  --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
-
-# Create DynamoDB table for state locking
-aws-vault exec tf-splunk-aws -- aws dynamodb create-table \
-  --table-name tf-splunk-aws-locks-useast2 \
-  --attribute-definitions AttributeName=LockID,AttributeType=S \
-  --key-schema AttributeName=LockID,KeyType=HASH \
-  --billing-mode PAY_PER_REQUEST \
-  --region us-east-2
-```
-
-Once these resources exist, `terragrunt init` will succeed and manage the state backend automatically.
-
-### Terraform Operations
-
-```bash
-# From terragrunt/dev/ (uses assume-role via tf-splunk-aws profile)
-aws-vault exec tf-splunk-aws -- doppler run -- terragrunt init
-aws-vault exec tf-splunk-aws -- doppler run -- terragrunt plan
-aws-vault exec tf-splunk-aws -- doppler run -- terragrunt apply
-
-# From modules/ (for testing without real credentials)
+tofu fmt -check -recursive
 tofu init -backend=false
 tofu validate
 tofu test -no-color
 ```
 
-### Doppler Environment Variables
+Real plans/applies use the standard AWS credential chain plus a var file:
 
-| Variable | Source | Purpose |
-| -------- | ------ | ------- |
-| `SPLUNK_PASSWORD` | Doppler | Splunk admin password (>= 8 chars) |
-| `NETWORK_PUBLIC_IP_ADDRESS` | Doppler | Home IP for web/HEC CIDR allowlists |
-
-## Module Structure
-
-```text
-modules/
-├── main.tf         # Root orchestrator, wires modules together
-├── variables.tf    # Root input variables
-├── outputs.tf      # Aggregated outputs
-├── network/        # VPC, subnets, route tables, IGW
-├── security/       # Security groups, IAM role/profile
-├── compute/        # NAT instance (source_dest_check=false)
-└── splunk/         # Splunk Enterprise instance + EBS
+```bash
+tofu init -backend-config=envs/dev.s3.tfbackend   # once per environment
+tofu plan  -var-file=envs/dev.tfvars
+tofu apply -var-file=envs/dev.tfvars
 ```
 
-## Secrets Management
+Secrets and operator IPs come from the environment, never from committed
+files: `TF_VAR_splunk_admin_password` (optional; generated when unset) and
+`TF_VAR_admin_ip_cidrs` (e.g. `'["203.0.113.7/32"]'`).
+
+### Post-apply: show cost and credentials
+
+After every `tofu apply`, run and display:
+
+```bash
+tofu output -json estimated_cost | jq .
+tofu output -json access_credentials | jq .
+```
+
+Then verify enabled service URLs respond before reporting success (services
+take 2–5 minutes to boot; retry up to 3 times at 30-second intervals):
+
+```bash
+curl -sf -o /dev/null -w '%{http_code}' http://<splunk_ip>:8000   # expect 303
+curl -sf -o /dev/null -w '%{http_code}' http://<cribl_ip>:4200    # expect 200/302
+```
+
+## Secrets management
 
 **NEVER** commit passwords or credentials. Use:
 
-- `aws_ssm_parameter` (SecureString) for Splunk admin password — retrieved at boot via `aws ssm get-parameter`
-- `aws-vault` for AWS credentials
-- Instance role + SSM for instance-level secrets
+- `aws_ssm_parameter` (SecureString) for the Splunk admin password —
+  retrieved at boot via the instance role
+- `TF_VAR_*` environment variables for operator-supplied secrets
+- Mark secret variables `sensitive = true`
 
 ## Testing
 
-Tests use mock providers - no AWS credentials needed:
+Tests use mock providers — no AWS credentials needed. Run the whole suite with
+`tofu test`. Test files live in `tests/` (one `*.tftest.hcl` per concern).
 
-```bash
-cd modules/
-tofu init -backend=false
-tofu test -no-color
-```
+## Version management
 
-## Security Notes
+Pin dependency versions for reproducibility: `~> X.Y` for providers (patch
+flexibility, locked major/minor), `>= X.Y` only for true minimums like
+`required_version`.
 
-- SSH disabled by default (`ssh_allowed_cidrs = []` — empty list creates no SSH rule)
-- SSH access requires explicit CIDR allowlist via `ssh_allowed_cidrs` variable
-- Use SSM Session Manager for shell access (already installed on all instances)
-- All instances in private subnets except NAT
-- Splunk accessible only from within VPC
+## Development workflow
 
-## Critical: Version Management
+Before ANY commit: `tofu fmt -check -recursive`, `tofu init -backend=false`,
+`tofu validate`, `tofu test -no-color`. Use feature branches and
+[Conventional Commits](https://www.conventionalcommits.org); releases are cut
+by release-please.
 
-Pin dependency versions for reproducibility. Use `~> X.Y` for patch-level flexibility
-while locking major/minor versions. This avoids unexpected breaking changes from upstream
-updates while still receiving bug fixes.
-
-- Use `~> X.Y` (e.g., `~> 6.0`) for provider versions — allows patch releases, locks major/minor
-- Use `>= X.Y` only when a minimum version is required and newer versions are all acceptable
-- Avoid overly tight constraints (e.g., `= X.Y.Z`) unless exact reproducibility is critical
-
-## Development Workflow
-
-**Before ANY commits**, run validation:
-
-```bash
-# Validate syntax (no credentials needed)
-tofu init -backend=false
-tofu validate
-
-# Full plan (requires AWS credentials)
-aws-vault exec tf-splunk-aws -- doppler run -- terragrunt plan
-```
-
-**Best Practices**:
-
-- Use feature branches for all changes
-- Follow conventional commit messages
-- Mark secrets with `sensitive = true` in variables
-- Never commit `.terraform/` or state files
-- Remote state with encryption (S3 + DynamoDB)
-
-## PR Review Checklist
+## PR review checklist
 
 - [ ] No exposed secrets or credentials
-- [ ] Variables documented with `sensitive = true` where needed
-- [ ] `tofu validate` passes (no credentials needed)
+- [ ] Variables documented, `sensitive = true` where needed
+- [ ] `tofu validate` and `tofu test` pass (no credentials needed)
 - [ ] Conventional commit message
 - [ ] Documentation updated if needed
 - [ ] Cost impact considered

--- a/README.md
+++ b/README.md
@@ -1,76 +1,322 @@
-# TF-Splunk-AWS
+# tf-splunk-aws
 
-[![CI](https://github.com/JacobPEvans/tf-splunk-aws/actions/workflows/terraform.yml/badge.svg)](https://github.com/JacobPEvans/tf-splunk-aws/actions/workflows/terraform.yml)
-[![License](https://img.shields.io/github/license/JacobPEvans/tf-splunk-aws)](LICENSE)
+[![OpenTofu CI](../../actions/workflows/tofu-ci.yml/badge.svg)](../../actions/workflows/tofu-ci.yml)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Cost-optimized Splunk infrastructure on AWS using OpenTofu and Terragrunt.
-**~$8.54–$17.67/month** (optional auto-lifecycle). This module provisions a
-Splunk-ready AWS footprint — network, security, compute, and a running Splunk
-instance — that a downstream configurator can take over for index and data setup.
+Cost-optimized Splunk Enterprise and/or Cribl environment on AWS, managed with
+plain [OpenTofu](https://opentofu.org). Instances stop themselves after 24
+hours, and authorized GitHub users can start ("summon") the environment from
+the Actions tab with zero AWS credentials.
 
 ## What & Why
 
-**What**: Production-ready Splunk deployment on AWS with modular Terraform architecture
-**Why**: Demonstrates cost optimization, infrastructure-as-code best practices, and security-first design
+This repository provisions an on-demand data-ingest environment:
 
-## Quick Facts
+- **Splunk Enterprise** (optional, on by default) — a single indexer/search
+  head with a dedicated EBS data volume.
+- **Cribl Stream + Cribl Edge** (optional, off by default) — a Linux Stream
+  leader and a Windows Edge worker for routing/shaping data.
+- **Shared plumbing** — VPC with public/private subnets, a t4g.nano NAT
+  instance (instead of a ~$32/mo NAT Gateway), security groups, IAM, and
+  SSM-based secrets.
 
-- **Cost**: ~$17.67/month while running; an `enable_auto_stop` guardrail stops the whole stack on a nightly schedule so it can't quietly run up the bill
-- **Architecture**: 4 modules (network, security, compute, splunk)
-- **Deployment**: Terragrunt-managed with remote state
-- **Security**: Encrypted storage, IAM least privilege, VPC isolation
+Either workload deploys independently (`enable_splunk` / `enable_cribl`);
+cost control is built in rather than bolted on.
 
-## Cost Breakdown
+## Cost
 
-| Resource | Running | Stopped (by guardrail) |
-| -------- | ------- | ---------------------- |
-| NAT Instance (t4g.nano) | $2.52 | $0 |
-| Splunk Instance (t3a.small) | $12.18 | $0 |
-| EBS Storage (70GB GP3) | $2.97 | $2.97 |
-| **Total** | **~$17.67** | **~$2.97** |
+Approximate on-demand pricing in us-east-2 (see the `estimated_cost` output
+for the live computed figure):
 
-Index data lives on the local EBS volume. Cribl handles long-term archive to S3
-out-of-band, so this module no longer manages a SmartStore bucket.
-The `enable_auto_stop` guardrail runs the AWS-owned `AWS-StopEC2Instance` runbook on
-a schedule (nightly by default) via EventBridge Scheduler, stopping every
-`Project=splunk-aws` instance — no Lambda, tag-driven. The stack only costs the
-"Running" rate while actively in use and drops to EBS-only once stopped; compute and
-public-IPv4 charges stop with the instances.
+| Component | Running | Stopped |
+| --------- | ------- | ------- |
+| NAT instance (t4g.nano) | ~$3.07/mo | $0 |
+| Splunk (t3a.small + 70 GB gp3) | ~$19.32/mo | ~$5.60/mo (EBS) |
+| Cribl Stream (t3a.small) | ~$16.12/mo | ~$2.40/mo (EBS) |
+| Cribl Edge (t3a.medium, Windows) | ~$56.71/mo | ~$2.40/mo (EBS) |
+| Auto-stop schedule | ~$0 (free tier) | ~$0 |
+
+With the default guardrail, a daily stop caps runtime at under 24 hours, so
+real spend approaches the "stopped" column plus hours actually used.
+
+### Automatic shutdown (default on)
+
+`modules/lifecycle` provisions an EventBridge Scheduler that invokes AWS's
+built-in `AWS-StopEC2Instance` SSM runbook on `stop_schedule_expression`
+(default `cron(0 8 * * ? *)` — nightly 08:00 UTC), stopping every instance
+tagged `Project=splunk-aws`. It is tag-driven and fully AWS-native (no code),
+so it catches every instance regardless of how it was started. A daily
+schedule caps maximum runtime at under 24 hours.
 
 ## Installation
 
-This repo pins its toolchain (`tofu`, `terragrunt`, and friends) in a
-[Nix dev shell][nix-develop], wired up through the committed `.envrc`. Activate it
-once per worktree — `direnv` reads `.envrc` and loads the shell automatically:
+Requirements:
+
+- [OpenTofu](https://opentofu.org) >= 1.10 (`tofu`)
+- AWS CLI v2 with credentials for the target account (env vars, SSO, or any
+  standard credential source)
 
 ```bash
-direnv allow
+git clone <this-repo>
+cd tf-splunk-aws
 ```
 
-AWS credentials must be available in the environment (the remote state backend
-and provider both authenticate against AWS).
+## First-time AWS setup
 
-[nix-develop]: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-develop.html
+One-time, per AWS account. Run with an admin-capable identity.
+
+### 1. Create the state bucket
+
+State locking uses S3 native lockfiles (OpenTofu >= 1.10) — no DynamoDB table.
+
+```bash
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REGION=us-east-2
+BUCKET="tf-splunk-aws-state-${REGION}-${ACCOUNT_ID}"
+
+aws s3api create-bucket \
+  --bucket "$BUCKET" --region "$REGION" \
+  --create-bucket-configuration LocationConstraint="$REGION"
+
+aws s3api put-bucket-versioning \
+  --bucket "$BUCKET" --versioning-configuration Status=Enabled
+
+aws s3api put-bucket-encryption \
+  --bucket "$BUCKET" \
+  --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+
+aws s3api put-public-access-block \
+  --bucket "$BUCKET" \
+  --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+```
+
+Then replace `<ACCOUNT_ID>` in `envs/*.s3.tfbackend` with your account id.
+
+### 2. Create the deployer policy and role/user
+
+The identity that runs `tofu plan/apply` needs the policy below (replace
+`<ACCOUNT_ID>`). Attach it to a role (recommended, e.g. via your SSO
+permission set) or an IAM user.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TerraformState",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::tf-splunk-aws-state-us-east-2-<ACCOUNT_ID>",
+        "arn:aws:s3:::tf-splunk-aws-state-us-east-2-<ACCOUNT_ID>/*"
+      ]
+    },
+    {
+      "Sid": "NetworkAndCompute",
+      "Effect": "Allow",
+      "Action": "ec2:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "InstanceSecrets",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:PutParameter",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:DeleteParameter",
+        "ssm:ListTagsForResource",
+        "ssm:AddTagsToResource",
+        "ssm:RemoveTagsFromResource",
+        "ssm:DescribeParameters"
+      ],
+      "Resource": "arn:aws:ssm:*:<ACCOUNT_ID>:parameter/*/splunk/*"
+    },
+    {
+      "Sid": "GuardrailScheduling",
+      "Effect": "Allow",
+      "Action": "scheduler:*",
+      "Resource": "arn:aws:scheduler:*:<ACCOUNT_ID>:schedule/default/*"
+    },
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:PutRetentionPolicy",
+        "logs:DeleteLogGroup",
+        "logs:DescribeLogGroups",
+        "logs:ListTagsForResource",
+        "logs:TagResource",
+        "logs:UntagResource",
+        "logs:TagLogGroup",
+        "logs:UntagLogGroup"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IamForInstanceAndSchedulerRoles",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:TagRole",
+        "iam:UntagRole",
+        "iam:PutRolePolicy",
+        "iam:GetRolePolicy",
+        "iam:DeleteRolePolicy",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListInstanceProfilesForRole",
+        "iam:PassRole",
+        "iam:CreateInstanceProfile",
+        "iam:DeleteInstanceProfile",
+        "iam:GetInstanceProfile",
+        "iam:AddRoleToInstanceProfile",
+        "iam:RemoveRoleFromInstanceProfile",
+        "iam:TagInstanceProfile"
+      ],
+      "Resource": [
+        "arn:aws:iam::<ACCOUNT_ID>:role/*-splunk-*",
+        "arn:aws:iam::<ACCOUNT_ID>:role/*-cribl-*",
+        "arn:aws:iam::<ACCOUNT_ID>:role/*-splunk-aws-*",
+        "arn:aws:iam::<ACCOUNT_ID>:instance-profile/*"
+      ]
+    },
+    {
+      "Sid": "GithubOidcProvider",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateOpenIDConnectProvider",
+        "iam:DeleteOpenIDConnectProvider",
+        "iam:GetOpenIDConnectProvider",
+        "iam:TagOpenIDConnectProvider",
+        "iam:UntagOpenIDConnectProvider"
+      ],
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+    },
+    {
+      "Sid": "ReadOnlyLookups",
+      "Effect": "Allow",
+      "Action": [
+        "sts:GetCallerIdentity",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+> `ec2:*` on `*` is used because this stack creates and destroys VPCs,
+> subnets, security groups, key pairs, volumes, and instances. Scope it
+> further with tag conditions if your organization requires it.
+
+### 3. Set secrets and variables
+
+| Where | Name | Value |
+| ----- | ---- | ----- |
+| Shell env (optional) | `TF_VAR_splunk_admin_password` | Splunk admin password (>= 8 chars). Omit to auto-generate. |
+| Shell env | `TF_VAR_admin_ip_cidrs` | Your operator egress IPs, e.g. `'["203.0.113.7/32"]'` |
+| GitHub repo → Actions variables | `SUMMON_ROLE_ARN` | `tofu output -raw summon_role_arn` |
+| GitHub repo → Actions variables | `AWS_REGION` (optional) | Defaults to `us-east-2` |
 
 ## Usage
 
-Each environment lives under `terragrunt/` (`dev`, `stg`, `prod`). Plan and apply
-from the target environment directory:
-
 ```bash
-cd terragrunt/dev
-terragrunt plan    # Review 22 resources
-terragrunt apply   # Deploy infrastructure
+# One-time per environment (after replacing <ACCOUNT_ID> in the tfbackend file)
+tofu init -backend-config=envs/dev.s3.tfbackend
+
+tofu plan  -var-file=envs/dev.tfvars
+tofu apply -var-file=envs/dev.tfvars
+
+# Connection details and generated credentials
+tofu output connection_info
+tofu output access_credentials
+tofu output estimated_cost
+
+# Tear down
+tofu destroy -var-file=envs/dev.tfvars
 ```
 
-## Documentation
+Deploy only one workload by flipping the toggles in the tfvars file (or on
+the CLI):
 
-| Document | Purpose | Read Time |
-| -------- | ------- | --------- |
-| **[Project Scope](.copilot/PROJECT.md)** | Business context, constraints | 2 min |
-| **[Architecture](.copilot/ARCHITECTURE.md)** | Technical decisions, current state | 5 min |
-| **[Implementation](modules/README.md)** | Module details, developer guide | 10 min |
+```bash
+tofu apply -var-file=envs/dev.tfvars -var enable_splunk=false -var enable_cribl=true
+```
 
----
+### Summon: start/stop with zero AWS credentials
 
-> Part of a [larger ecosystem of ~40 repos](https://docs.jacobpevans.com) — see how it all fits together.
+Set `enable_github_summon = true` and `github_repository = "<owner>/<repo>"`
+in your tfvars, apply, and wire the `summon_role_arn` output into the
+repository's `SUMMON_ROLE_ARN` Actions variable (table above). Then anyone with
+write access to the repo can run **Actions → Summon environment → Run workflow**:
+
+- `action: start` — starts the NAT instance first, then the workload
+  instances, and prints instance IPs to the job summary. The scheduled stop
+  (below) turns everything off again on its schedule.
+- `action: stop` — stops every instance in the stack immediately.
+
+Because it's a plain `workflow_dispatch`, it also works from anywhere that
+can trigger GitHub workflows — the GitHub mobile app, `gh workflow run
+summon.yml -f action=start`, or Slack via the
+[GitHub app for Slack](https://github.com/integrations/slack)
+(`/github run <owner>/<repo> summon.yml`).
+
+## Module structure
+
+```text
+main.tf / variables.tf / outputs.tf   Root module (this directory)
+envs/                                 Per-environment tfvars + backend configs
+tests/                                Mock-provider test suite (tofu test)
+modules/
+├── network/      VPC, subnets, route tables, IGW
+├── security/     Security groups, IAM roles/profiles, SSM password
+├── compute/      NAT instance
+├── splunk/       Splunk Enterprise instance + EBS data volume (optional)
+├── cribl/        Cribl Stream (Linux) + Cribl Edge (Windows) (optional)
+├── cribl-config/ Declarative Cribl objects via the criblio provider (optional)
+├── lifecycle/    Scheduled stop via the AWS-StopEC2Instance runbook
+└── summon/       GitHub Actions OIDC role for credential-less start/stop
+```
+
+## Testing
+
+No AWS credentials needed — the suite uses mock providers:
+
+```bash
+tofu init -backend=false
+tofu test -no-color
+```
+
+See [docs/instance-management.md](docs/instance-management.md) for day-2
+start/stop operations.
+
+## Security notes
+
+- SSH is disabled by default (`ssh_allowed_cidrs = []` creates no SSH rule);
+  use SSM Session Manager for shell access.
+- The Splunk admin password lives in SSM Parameter Store (SecureString) and
+  is fetched by the instance at boot — never embedded in user data.
+- Workload instances sit in private subnets unless `splunk_public_access`
+  is enabled, and even then every ingress port is allowlist-gated.
+- `allow_all_ips` exists for short-lived testing only and is never committed.
+
+## Contributing
+
+1. Branch, change, and run the validation stack before pushing:
+   `tofu fmt -check -recursive && tofu init -backend=false && tofu validate && tofu test -no-color`.
+2. Use [Conventional Commits](https://www.conventionalcommits.org) — releases
+   are cut automatically by release-please.
+3. CI must be green (`OpenTofu CI`, `Markdown Lint`) before merge.
+
+## License
+
+[MIT](LICENSE)

--- a/docs/instance-management.md
+++ b/docs/instance-management.md
@@ -1,180 +1,70 @@
-# Instance Management — Pause & Resume
+# Instance Management — Summon, Pause & Resume
 
-Procedures for stopping and starting the Splunk dev/DR instances to save money
-without destroying any infrastructure or data.
+Procedures for starting and stopping the environment to save money without
+destroying any infrastructure or data. Stopped instances cost only their EBS
+storage; all index data survives on the persistent data volume.
 
-## What Persists Across Stop/Start
+## Primary path: the summon workflow (no AWS credentials)
 
-| Resource | Persists? | Notes |
-| ---------- | --------- | ----- |
-| EBS root volume | Yes | OS, Splunk install, config |
-| EBS data volume | Yes | Splunk index data (hot/warm/cold) |
-| SSM parameters | Yes | Admin password |
-| Security groups | Yes | Firewall rules |
-| IAM role | Yes | Instance permissions |
-| VPC / subnets | Yes | Network topology |
-| **Public IP** | **No** | New IP assigned on each start |
-| Instance ID | Yes | Does not change |
+With `enable_github_summon = true` applied and the repository variables wired
+(see the README's "First-time AWS setup"), anyone with write access to the
+repository can start or stop the stack:
 
-> EBS data volume holds the full Splunk index history across any stop/start cycle.
-> Long-term archive lives in a separate Cribl-managed S3 bucket outside this module.
+1. GitHub → **Actions → Summon environment → Run workflow**
+2. Choose `action: start` or `action: stop`
+3. The job summary shows every instance's state and IPs when it finishes
 
----
-
-## Cost Analysis
-
-### Always-On (baseline)
-
-| Resource | Monthly |
-| ---------- | ------- |
-| NAT t4g.nano (us-east-2) | ~$2.52 |
-| Splunk t3a.small (us-east-2) | ~$12.18 |
-| EBS 70 GB gp3 | ~$2.97 |
-| **Total** | **~$17.67** |
-
-### Paused (instances stopped, data retained)
-
-| Resource | Monthly |
-| ---------- | ------- |
-| NAT t4g.nano — stopped | $0.00 |
-| Splunk t3a.small — stopped | $0.00 |
-| EBS 70 GB gp3 (still billed) | ~$2.97 |
-| **Total** | **~$2.97** |
-
-### With Auto-Lifecycle (EventBridge scheduled)
-
-Default config: start every 4 hours, run 60 minutes = ~25% utilization.
-
-| Resource | Monthly |
-| ---------- | ------- |
-| Splunk t3a.small × 25% | ~$3.05 |
-| NAT t4g.nano (must stay on for egress routing) | ~$2.52 |
-| EBS | ~$2.97 |
-| **Total** | **~$8.54** |
-
----
-
-## Pause Procedure (stop both instances)
-
-Get the instance IDs from Terragrunt outputs first:
+Equivalent CLI and chat triggers:
 
 ```bash
-cd ~/git/tf-splunk-aws/main/terragrunt/dev
-aws-vault exec tf-splunk-aws -- doppler run -- terragrunt output
+gh workflow run summon.yml -f action=start
+gh workflow run summon.yml -f action=stop
 ```
 
-Note `splunk_instance_id` and `nat_instance_id` from the output.
+Slack users with the [GitHub app for Slack](https://github.com/integrations/slack)
+can trigger the same workflow with `/github run <owner>/<repo> summon.yml`.
 
-### Stop Splunk first (drain in-flight data)
+On `start`, the workflow starts the NAT instance first (private-subnet
+instances need their egress path up before they boot), then the workload
+instances.
+
+## Automatic shutdown
+
+Independent of how instances were started, the lifecycle module (default
+`enable_auto_stop = true`) runs the AWS-StopEC2Instance runbook on
+`stop_schedule_expression` (default nightly 08:00 UTC), stopping every
+`Project`-tagged instance. Console or CLI starts are covered too — a daily
+schedule caps runtime at under 24 hours.
+
+There is no auto-*start*: the stack stays off until deliberately summoned.
+
+## Fallback: manual AWS CLI
+
+Requires credentials with `ec2:StartInstances` / `ec2:StopInstances` on the
+tagged instances.
 
 ```bash
-aws-vault exec tf-splunk-aws -- aws ec2 stop-instances \
-  --instance-ids <splunk_instance_id> \
-  --region us-east-2
+# Discover instance IDs by tag
+aws ec2 describe-instances \
+  --filters "Name=tag:Project,Values=splunk-aws" \
+  --query 'Reservations[].Instances[].{id:InstanceId,name:Tags[?Key==`Name`]|[0].Value,state:State.Name}' \
+  --output table
+
+# Stop (workloads first, NAT last — order is a nicety, not a requirement)
+aws ec2 stop-instances --instance-ids <workload-ids> <nat-id>
+
+# Start (NAT first so private instances have egress when they boot)
+aws ec2 start-instances --instance-ids <nat-id>
+aws ec2 wait instance-running --instance-ids <nat-id>
+aws ec2 start-instances --instance-ids <workload-ids>
 ```
 
-Wait for Splunk to reach `stopped` state (~30–60 s):
+## After a restart
 
-```bash
-aws-vault exec tf-splunk-aws -- aws ec2 wait instance-stopped \
-  --instance-ids <splunk_instance_id> \
-  --region us-east-2
-```
-
-### Stop NAT
-
-```bash
-aws-vault exec tf-splunk-aws -- aws ec2 stop-instances \
-  --instance-ids <nat_instance_id> \
-  --region us-east-2
-
-aws-vault exec tf-splunk-aws -- aws ec2 wait instance-stopped \
-  --instance-ids <nat_instance_id> \
-  --region us-east-2
-```
-
-Both instances are now stopped. EBS continues to bill; compute does not.
-
----
-
-## Resume Procedure (start instances, get new IP)
-
-### Start NAT first (restores routing before Splunk)
-
-```bash
-aws-vault exec tf-splunk-aws -- aws ec2 start-instances \
-  --instance-ids <nat_instance_id> \
-  --region us-east-2
-
-aws-vault exec tf-splunk-aws -- aws ec2 wait instance-running \
-  --instance-ids <nat_instance_id> \
-  --region us-east-2
-```
-
-### Start Splunk
-
-```bash
-aws-vault exec tf-splunk-aws -- aws ec2 start-instances \
-  --instance-ids <splunk_instance_id> \
-  --region us-east-2
-
-aws-vault exec tf-splunk-aws -- aws ec2 wait instance-running \
-  --instance-ids <splunk_instance_id> \
-  --region us-east-2
-```
-
-### Get the new public IP
-
-```bash
-aws-vault exec tf-splunk-aws -- aws ec2 describe-instances \
-  --instance-ids <splunk_instance_id> \
-  --region us-east-2 \
-  --query 'Reservations[0].Instances[0].PublicIpAddress' \
-  --output text
-```
-
-Splunk Web is available at `http://<new-ip>:8000` after ~2–3 minutes boot time.
-On resume, Splunk starts automatically via the boot-start service configured during
-first-boot provisioning. If `enable_auto_stop = true`, the scheduled auto-stop guardrail
-will stop the instance again at the next scheduled run (nightly by default).
-
----
-
-## Notes
-
-### State drift
-
-OpenTofu does not manage instance power state, so stopping instances via AWS CLI
-does not create plan drift. A `terragrunt plan` after pause will show no changes.
-
-### Boot time
-
-Allow ~2–3 minutes after `instance-running` before Splunk Web is reachable.
-On resume, Splunk starts via the boot-start service; first-boot provisioning
-(package install, SSM password retrieval) does not repeat.
-
-### Data ingestion during pause
-
-On-prem forwarders will queue events locally (Splunk's disk-based queue) and
-replay them when connectivity is restored. No events are lost as long as the
-on-prem queue does not fill up.
-
-### Auto-stop guardrail
-
-For automated cost control without manual steps, set `enable_auto_stop = true`
-in `terragrunt/dev/terragrunt.hcl` (the dev default). An EventBridge Scheduler runs
-the AWS-owned `AWS-StopEC2Instance` runbook on a schedule (`stop_schedule_expression`,
-nightly 08:00 UTC by default) that stops every `Project=splunk-aws` instance — Splunk,
-both Cribl boxes, and the NAT instance. It is tag-driven and uses no Lambda or custom
-code, and because it stops via the EC2 API it also covers the Windows Cribl Edge
-instance. There is no auto-start: the stack stays off until you deliberately start it,
-then stops again at the next scheduled run. Set `stop_schedule_expression = "rate(48 hours)"`
-for a looser ~48h lease.
-
-### Elastic IP (EIP)
-
-The current dev deployment does not use an EIP, so the Splunk public IP changes
-on every start. To get a stable IP, add an EIP resource to the compute module
-and associate it with the Splunk instance. EIPs are free when attached to a
-running instance; they cost ~$3.65/mo when unattached (i.e., while Splunk is
-paused). Factor that into the cost model before enabling.
+- Public IPs change on every stop/start cycle (no Elastic IPs are allocated,
+  by design — an EIP attached to a stopped instance bills hourly). Fetch the
+  new IPs from the summon job summary or `describe-instances`.
+- Splunk and Cribl are installed as boot-start services; first-boot
+  provisioning does not repeat. Give services 2–5 minutes after start.
+- If access stops working after a restart, your operator IP may have changed:
+  update `TF_VAR_admin_ip_cidrs` and re-apply.

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@
 #   splunk    Splunk Enterprise instance + EBS data volume (optional)
 #   cribl     Cribl Stream (Linux) + Cribl Edge (Windows) instances (optional)
 #   lifecycle Scheduled stop of Project-tagged instances (AWS-StopEC2Instance)
+#   summon    GitHub Actions OIDC role for credential-less start/stop
 #
 # Splunk and Cribl are independently optional (enable_splunk / enable_cribl);
 # the network, NAT, and guardrail layers are shared infrastructure.
@@ -246,6 +247,18 @@ module "lifecycle" {
   project_tag              = var.project_tag
   enable_auto_stop         = var.enable_auto_stop
   stop_schedule_expression = var.stop_schedule_expression
+}
+
+# GitHub Actions OIDC role so authorized repository users can start/stop the
+# environment ("summon") with zero AWS credentials of their own.
+module "summon" {
+  source = "./modules/summon"
+
+  enable_github_summon     = var.enable_github_summon
+  environment              = var.environment
+  project_tag              = var.project_tag
+  github_repository        = var.github_repository
+  github_oidc_provider_arn = var.github_oidc_provider_arn
 }
 
 # Plan-time guard: when the criblio config layer is enabled, both the

--- a/modules/summon/main.tf
+++ b/modules/summon/main.tf
@@ -1,0 +1,107 @@
+# Summon module — lets authorized GitHub users start/stop this environment
+# with zero AWS credentials of their own.
+#
+# The .github/workflows/summon.yml workflow authenticates to AWS via GitHub
+# Actions OIDC and assumes the role created here. The role can only:
+#   * start/stop instances carrying the Project tag,
+#   * describe instances (to report IPs in the job summary).
+#
+# The lifecycle module's scheduled stop turns the environment off again on its
+# schedule, regardless of how it was started.
+
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+data "aws_partition" "current" {
+  count = local.enabled
+}
+
+locals {
+  enabled = var.enable_github_summon ? 1 : 0
+
+  common_tags = {
+    Environment = var.environment
+    Project     = var.project_tag
+    ManagedBy   = "opentofu"
+  }
+
+  # Reuse an existing OIDC provider when given; otherwise create one below.
+  # Null when the module is disabled (nothing references it then).
+  oidc_provider_arn = var.enable_github_summon ? coalesce(
+    var.github_oidc_provider_arn,
+    try(aws_iam_openid_connect_provider.github[0].arn, null)
+  ) : null
+}
+
+# GitHub Actions OIDC identity provider. An AWS account can hold only one
+# provider per issuer URL — pass github_oidc_provider_arn instead if your
+# account already has one.
+resource "aws_iam_openid_connect_provider" "github" {
+  count = var.enable_github_summon && var.github_oidc_provider_arn == null ? 1 : 0
+
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+
+  tags = local.common_tags
+}
+
+# Role assumed by the summon workflow. Trust is scoped to workflow runs on the
+# default branch of the configured repository.
+resource "aws_iam_role" "summon" {
+  count = local.enabled
+  name  = "${var.environment}-${var.project_tag}-summon"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = local.oidc_provider_arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = "repo:${var.github_repository}:ref:refs/heads/${var.github_branch}"
+        }
+      }
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy" "summon" {
+  count = local.enabled
+  name  = "${var.environment}-${var.project_tag}-summon"
+  role  = aws_iam_role.summon[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DescribeInstances"
+        Effect   = "Allow"
+        Action   = ["ec2:DescribeInstances", "ec2:DescribeInstanceStatus"]
+        Resource = "*"
+      },
+      {
+        # Start/stop limited to instances carrying the in-scope Project tag.
+        Sid      = "StartStopProjectInstances"
+        Effect   = "Allow"
+        Action   = ["ec2:StartInstances", "ec2:StopInstances"]
+        Resource = "arn:${data.aws_partition.current[0].partition}:ec2:*:*:instance/*"
+        Condition = {
+          StringEquals = { "aws:ResourceTag/Project" = var.project_tag }
+        }
+      },
+    ]
+  })
+}

--- a/modules/summon/outputs.tf
+++ b/modules/summon/outputs.tf
@@ -1,0 +1,12 @@
+# Summon module outputs. All are null when enable_github_summon = false.
+# Wire these into the repository's Actions variables (see README).
+
+output "summon_role_arn" {
+  description = "ARN of the role the summon workflow assumes via OIDC (repository variable SUMMON_ROLE_ARN)."
+  value       = one(aws_iam_role.summon[*].arn)
+}
+
+output "oidc_provider_arn" {
+  description = "ARN of the GitHub OIDC provider in use (created or reused)."
+  value       = var.enable_github_summon ? local.oidc_provider_arn : null
+}

--- a/modules/summon/variables.tf
+++ b/modules/summon/variables.tf
@@ -1,0 +1,43 @@
+# Summon module variables.
+
+variable "enable_github_summon" {
+  description = "Create the GitHub Actions OIDC role and lease scheduler role. When false, this module creates nothing."
+  type        = bool
+  default     = false
+}
+
+variable "environment" {
+  description = "Environment name used to namespace resources."
+  type        = string
+}
+
+variable "project_tag" {
+  description = "Value of the Project tag identifying instances the summon role may start/stop."
+  type        = string
+  default     = "splunk-aws"
+}
+
+variable "github_repository" {
+  description = "GitHub repository (owner/name) trusted to assume the summon role."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = !var.enable_github_summon || can(
+      regex("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", var.github_repository)
+    )
+    error_message = "github_repository (owner/name) is required when enable_github_summon = true."
+  }
+}
+
+variable "github_branch" {
+  description = "Branch whose workflow runs may assume the summon role."
+  type        = string
+  default     = "main"
+}
+
+variable "github_oidc_provider_arn" {
+  description = "ARN of an existing GitHub Actions OIDC identity provider to reuse. Leave null to create one."
+  type        = string
+  default     = null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -122,6 +122,13 @@ output "cribl_edge_public_ip" {
   value       = module.cribl.cribl_edge_public_ip
 }
 
+# --- Summon ---------------------------------------------------------------------
+
+output "summon_role_arn" {
+  description = "ARN of the GitHub Actions summon role (null when disabled). Set this as the SUMMON_ROLE_ARN repository variable."
+  value       = module.summon.summon_role_arn
+}
+
 # --- Cost estimate --------------------------------------------------------------
 # On-demand us-east-2 pricing, computed from the enabled components. EBS is
 # billed while instances are stopped; compute is not, which is why the

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "aws_region" {
 }
 
 variable "project_tag" {
-  description = "Value of the Project tag applied to every resource. The auto-stop guardrail targets instances by this tag, so all instances in scope must share it."
+  description = "Value of the Project tag applied to every resource. The auto-stop guardrail and the summon role target instances by this tag, so all instances in scope must share it."
   type        = string
   default     = "splunk-aws"
 }
@@ -58,6 +58,29 @@ variable "stop_schedule_expression" {
     condition     = can(regex("^(cron|rate)\\(", var.stop_schedule_expression))
     error_message = "stop_schedule_expression must be a cron(...) or rate(...) expression."
   }
+}
+
+variable "enable_github_summon" {
+  description = "Create the GitHub Actions OIDC role that lets the summon workflow start/stop this environment without AWS credentials. Requires github_repository."
+  type        = bool
+  default     = false
+}
+
+variable "github_repository" {
+  description = "GitHub repository (owner/name) trusted to assume the summon role. Required when enable_github_summon = true."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.github_repository == "" || can(regex("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", var.github_repository))
+    error_message = "github_repository must be in owner/name form, e.g. my-org/tf-splunk-aws."
+  }
+}
+
+variable "github_oidc_provider_arn" {
+  description = "ARN of an existing GitHub Actions OIDC identity provider to reuse. Leave null to create one (an AWS account can only hold one provider per issuer URL)."
+  type        = string
+  default     = null
 }
 
 # --- Network ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds "summon" — start/stop the environment from GitHub Actions with zero AWS credentials, via an OIDC-assumed role. Third of a 4-PR split (replaces #224); **stacked on #227**.

> **Base is `refactor/opentofu-core` (#227)** — review the [summon diff](https://github.com/dryvist/tf-splunk-aws/compare/refactor/opentofu-core...feat/summon-oidc): the summon module, its workflow, and the root wiring only.

## Changes

- `modules/summon` — GitHub Actions OIDC identity provider (created or reused) + role, gated by `enable_github_summon` (default false). The role is limited to `ec2:Describe*` and tag-scoped `ec2:Start/StopInstances` on `Project`.
- `.github/workflows/summon.yml` — `workflow_dispatch` start/stop. `start` boots the NAT instance first (private-subnet egress), then the workloads; `stop` stops the stack. Reports instance state to the job summary.
- Root wiring: `module "summon"` block, `enable_github_summon` / `github_repository` / `github_oidc_provider_arn` variables, and the `summon_role_arn` output.

## Test Plan

- `tofu fmt -check -recursive`, `tofu validate` — clean
- `tofu test -no-color` — **73 passed, 0 failed**
- `tofu plan` with `enable_github_summon=true` + `github_repository` — 0 errors, creates the OIDC role