### PR TITLE
feat: add issue-auto-resolve + backlog-sweep AI automation

### DIFF
--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -1,0 +1,83 @@
+name: Issue Auto-Resolve
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to resolve"
+        required: true
+        type: string
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  actions: write
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  dispatch:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      issues: write
+    steps:
+      - name: Dispatch as workflow_dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          # Filter labeled events to only ai:ready
+          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" != "ai:ready" ]]; then
+            echo "Label '$LABEL_NAME' is not ai:ready — skipping"
+            exit 0
+          fi
+
+          # Daily dispatch limit (cost control safety valve)
+          TODAY=$(date -u +%Y-%m-%d)
+          COUNT=$(gh run list \
+            --workflow "$WORKFLOW_NAME" \
+            --repo "$REPO" \
+            --event workflow_dispatch \
+            --created ">=$TODAY" \
+            --json databaseId --jq 'length')
+          if [[ "$COUNT" -ge 5 ]]; then
+            echo "Daily dispatch limit reached ($COUNT/5) — skipping"
+            exit 0
+          fi
+
+          # Remove ai:ready label so it can be re-applied to re-trigger
+          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "ai:ready" ]]; then
+            gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label "ai:ready" || true
+          fi
+
+          gh workflow run "$WORKFLOW_NAME" \
+            --repo "$REPO" \
+            -f issue_number="$ISSUE_NUM"
+
+  run-triage:
+    if: github.event_name == 'workflow_dispatch'
+    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@main
+    secrets: inherit
+    with:
+      issue_number: ${{ inputs.issue_number }}
+
+  resolve-issue:
+    needs: [run-triage]
+    if: >-
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
+    uses: dryvist/ai-workflows/.github/workflows/cc-issue-resolver.yml@main
+    secrets: inherit
+    with:
+      repo_context: "Terraform/Terragrunt deploying Splunk on AWS (VPC, EC2, EBS, IAM)"
+      extra_tools: "Bash(terraform:*)"
+      issue_number: ${{ inputs.issue_number }}

--- a/.github/workflows/issue-backlog-sweep.yml
+++ b/.github/workflows/issue-backlog-sweep.yml
@@ -1,0 +1,43 @@
+# Backlog activation. On a slow schedule (and on demand), Claude judges the
+# oldest UNTRIAGED open issues and labels the auto-resolvable ones `ai:ready`
+# via the App token, which fires issue-auto-resolve.yml (issues: labeled) to
+# open the resolving PR. This is how the pre-existing backlog shrinks.
+#
+# The schedule is deliberate: a backlog is static state, not an event, so there
+# is nothing to trigger on. Keep the cadence slow — it only tops up the
+# ai:ready queue as the resolver drains it.
+#
+# Throttling: the reusable's max_issues (default 5) caps labels per run; the
+# resolver's own PR ceiling (5 bot PRs / 24h) is the hard backstop on PRs opened.
+#
+# No `with: max_issues` / workflow_dispatch input here: referencing the `inputs`
+# context in a reusable-call `with:` while a `schedule` trigger is present makes
+# GitHub startup-fail every run (`inputs` is undefined for scheduled events). The
+# reusable's default (5) is used for both the weekly run and manual dispatches.
+
+name: Issue Backlog Sweep
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * 1" # Mondays 09:00 UTC — top up the ai:ready queue weekly
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: read
+
+# No caller-level `concurrency:` — the reusable already sets the identical group
+# (issue-backlog-sweep-${{ github.repository }}). A caller sharing the reusable's
+# exact concurrency group holds that slot, so the reusable's jobs can never
+# acquire it → the run startup-fails with 0 jobs. Let the reusable queue runs.
+
+jobs:
+  sweep:
+    uses: dryvist/ai-workflows/.github/workflows/issue-backlog-sweep.yml@v0
+    # Org-level secrets can only be forwarded to a reusable via `inherit` — GitHub
+    # rejects explicit mapping (`NAME: ${{ secrets.NAME }}`) of org secrets at
+    # instantiation (startup failure). zizmor's secrets-inherit audit is therefore
+    # a false positive here: the reusable is first-party and version-pinned.
+    secrets: inherit # zizmor: ignore[secrets-inherit]


### PR DESCRIPTION
Greenfield: adds the full backlog loop (sweep labels ai:ready -> resolver opens a gated PR) to this repo, which had no AI automation. Same proven template + guards as the live repos. NOTE: first run needs the `ai:ready` label to exist and the JacobPEvans-claude App installed — verify before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)