### PR TITLE
chore: gitignore .terragrunt-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ GEMINI.local.md
 AGENTS.local.md
 .aider*
 .specstory/
+
+# Terragrunt generated cache
+.terragrunt-cache/


### PR DESCRIPTION
The untracked `terragrunt/` tree was entirely `.terragrunt-cache` (regenerable module copies, no real source), so committing it would pollute the repo with machine-specific build artifacts. Added `.terragrunt-cache/` to `.gitignore` instead — nothing lost, it regenerates on next `terragrunt` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)