### PR TITLE
fix(renovate): inherit dryvist org default preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["local>dryvist/.github"]
 }


### PR DESCRIPTION
This repo extended only `config:recommended`, so it inherited **none** of the org trust tiers, grouping, or auto-merge policy. Now extends `local>dryvist/.github` (the org `default.json`, which already includes `config:recommended`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB5heppQHhv8xE1XWeeFVA