### PR TITLE
ci: migrate release-please to App-token reusable workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,12 +8,9 @@ permissions: {}
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    steps:
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
-        with:
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
+    uses: dryvist/.github/.github/workflows/_release-please.yml@main
+    secrets:
+      GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY: ${{ secrets.GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Replace the standalone `googleapis/release-please-action@v4.4.1` step (default `GITHUB_TOKEN`) with a thin caller of `dryvist/.github/.github/workflows/_release-please.yml@main`, which authenticates as the dryvist release GitHub App.
- Default-token release PRs don't emit workflow events, so this repo's release PRs weren't cleanly triggering CI. App-token auth fixes that.
- Manifest mode is unchanged: `release-please-config.json` and `.release-please-manifest.json` stay as-is (defaults on the reusable workflow already point at those paths).
- Mirrors the caller shape already used by `terraform-proxmox`, `terraform-runs-on`, and `tofu-unifi`.

## Test plan

- [ ] CI green on this PR
- [ ] Next merge to `main` produces a release PR opened by the App (not `github-actions[bot]`) that triggers PR-gate CI